### PR TITLE
fix: [IDP-1340] add check timeline not found

### DIFF
--- a/src/main/java/it/gov/pagopa/timeline/service/TimelineServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/timeline/service/TimelineServiceImpl.java
@@ -77,6 +77,11 @@ public class TimelineServiceImpl implements TimelineService {
         endDate);
     List<OperationDTO> operationListDTO = new ArrayList<>();
     List<Operation> operationList = timelineRepository.findByFilter(criteria, pageable);
+
+    if (operationList.isEmpty()){
+      throw new TimelineException(HttpStatus.NOT_FOUND.value() , "Timeline for the current user was not found");
+    }
+
     long count = timelineRepository.getCount(criteria);
     final Page<Operation> result = PageableExecutionUtils.getPage(operationList, pageable,
         () -> count);

--- a/src/test/java/it/gov/pagopa/timeline/service/TimelineServiceTest.java
+++ b/src/test/java/it/gov/pagopa/timeline/service/TimelineServiceTest.java
@@ -20,6 +20,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -214,6 +216,20 @@ class TimelineServiceTest {
   }
 
   @Test
+  void getTimelineEmpty(){
+    List<Operation> operations = new ArrayList<>();
+
+    Mockito.when(timelineRepositoryMock.findByFilter(Mockito.any(Criteria.class), Mockito.any(Pageable.class))).thenReturn(operations);
+
+    try {
+      timelineService.getTimeline(INITIATIVE_ID, USER_ID, OPERATION_TYPE, 1, 3,null,null);
+    }catch (TimelineException e){
+      assertEquals(HttpStatus.NOT_FOUND.value(), e.getCode());
+      assertEquals("Timeline for the current user was not found", e.getMessage());
+    }
+  }
+
+  @Test
   void getTimelineWithNoFirstOperation_ok() {
     List<Operation> operations = new ArrayList<>();
     operations.add(OPERATION);
@@ -224,17 +240,6 @@ class TimelineServiceTest {
     TimelineDTO resDto = timelineService.getTimeline(INITIATIVE_ID, USER_ID, OPERATION_TYPE, 1, 3, null, null);
     assertFalse(resDto.getOperationList().isEmpty());
     assertEquals(resDto.getLastUpdate(), OPERATION.getOperationDate());
-  }
-
-  @Test
-  void getTimeline_ko() {
-    try {
-      TimelineDTO resDto = timelineService.getTimeline(INITIATIVE_ID, USER_ID, OPERATION_TYPE, 0, 3,null,null);
-      assertNull(resDto.getLastUpdate());
-    } catch (TimelineException e) {
-      assertEquals(HttpStatus.NOT_FOUND.value(), e.getCode());
-      assertEquals("No operations have been made on this initiative!", e.getMessage());
-    }
   }
 
   @Test


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR is related to task [IDP-1340](https://pagopa.atlassian.net/browse/IDP-1340)

#### List of Changes
<!--- Describe your changes in detail -->

- Added exception if the timeline does not exist for the user

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
    - [X] Unit
    - [X] Integration (Narrow)
- Post-Deploy Test
    - [ ] Isolated Microservice
    - [ ] Broader Integration
    - [ ] Acceptance
    - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


[IDP-1340]: https://pagopa.atlassian.net/browse/IDP-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ